### PR TITLE
Fix rotation event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# pygattlib dir
+pygattlib/

--- a/nuimo.py
+++ b/nuimo.py
@@ -14,6 +14,7 @@ import logging
 from threading import Event
 from gattlib import GATTRequester, DiscoveryService
 import gattlib
+import struct
 
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.addHandler(logging.NullHandler())
@@ -211,7 +212,7 @@ class NuimoController(gattlib.GATTRequester):
 
     @staticmethod
     def rotation_event(received_data):
-        rotation_value = received_data[3] + (received_data[4] << 8)
+        rotation_value = struct.unpack("<h", received_data[3] + received_data[4])[0]
         if rotation_value >= 1 << 15:
             rotation_value -= 1 << 16
 


### PR DESCRIPTION
# Problem

I got this error if I used the wheel on my nuimo. 

```
Waiting for Nuimo events, use CTRL+C to quit
Traceback (most recent call last):
  File "/home/pi/nuimo-linux-python/nuimo.py", line 257, in on_notification
    event = self.event_factory(data, uuid)
  File "/home/pi/nuimo-linux-python/nuimo.py", line 266, in event_factory
    event = item['constructor'](received_data)
  File "/home/pi/nuimo-linux-python/nuimo.py", line 214, in rotation_event
    rotation_value = received_data[3] + (received_data[4] << 8)
TypeError: unsupported operand type(s) for <<: 'str' and 'int'
```
# Solution

See the diff. As fare as I'm aware this should create the same output, **BUT** testing is needed.

Tested with Python 3.4.2 and apparently it doesn't work.
## system infos

```
$ uname -r 
4.4.13-v7+
$ python --version
Python 2.7.9
```
