### PR TITLE
fixing swipe_direction

### DIFF
--- a/nuimo.py
+++ b/nuimo.py
@@ -234,7 +234,7 @@ class NuimoController(gattlib.GATTRequester):
                       NuimoGestureEvent.SWIPE_UP, NuimoGestureEvent.SWIPE_DOWN, 
                       NuimoGestureEvent.TOUCH_LEFT, NuimoGestureEvent.TOUCH_RIGHT,
                       NuimoGestureEvent.TOUCH_TOP, NuimoGestureEvent.TOUCH_BOTTOM ]
-        swipe_direction = received_data[3]
+        swipe_direction = int(received_data[3].encode('hex'), 16)
         event_kind = directions[swipe_direction]
         event = NuimoGestureEvent(event_kind, swipe_direction)
         return event


### PR DESCRIPTION
# Problem

I got this error if I used the swipe event on my nuimo. 

```
Traceback (most recent call last):
  File "/home/pi/nuimo-linux-python/nuimo.py", line 257, in on_notification
    event = self.event_factory(data, uuid)
  File "/home/pi/nuimo-linux-python/nuimo.py", line 266, in event_factory
    event = item['constructor'](received_data)
  File "/home/pi/nuimo-linux-python/nuimo.py", line 238, in swipe_event
    event_kind = directions[swipe_direction]
TypeError: list indices must be integers, not str
```
# Solution

See the diff. As fare as I'm aware this should create the same output, **BUT** testing is needed.

Tested with Python 3.4.2 and apparently it doesn't work.
## system infos

```
$ uname -r 
4.4.13-v7+
$ python --version
Python 2.7.9
```
