### PR TITLE
Update package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sh examples/install.sh pygattlib  # For Python 2.x
 sh examples/install.sh py3gattlib # For Python 3.x
 ```
 #### Install the dependencies
-1. `sudo apt-get install pkg-config libboost-python-dev libboost-thread-dev libbluetooth-dev libglib2.0-dev python-dev`
+1. `sudo apt-get install pkg-config libboost-python-dev libboost-thread-dev libbluetooth-dev libglib2.0-dev python-dev python-setuptool`
 
 #### Installing Pygattlib
 1. `hg clone https://bitbucket.org/OscarAcena/pygattlib`

--- a/examples/install.sh
+++ b/examples/install.sh
@@ -44,7 +44,7 @@ case "$cmd" in
     pygattlib)
 	echo "Installing Pygattlib and dependencies"
 	set -x
-	sudo apt-get install pkg-config libboost-python-dev libboost-thread-dev libbluetooth-dev libglib2.0-dev python-dev
+	sudo apt-get install pkg-config libboost-python-dev libboost-thread-dev libbluetooth-dev libglib2.0-dev python-dev python-setuptools
 	[ ! -d pygattlib ] && git clone https://github.com/matthewelse/pygattlib
 	cd pygattlib && sudo python setup.py install
 	;;
@@ -52,7 +52,7 @@ case "$cmd" in
     py3gattlib)
 	echo "Installing Pygattlib and dependencies for Python 3"
 	set -x
-	sudo apt-get install pkg-config libboost-python-dev libboost-thread-dev libbluetooth-dev libglib2.0-dev python-dev
+	sudo apt-get install pkg-config libboost-python-dev libboost-thread-dev libbluetooth-dev libglib2.0-dev python3-dev python3-setuptool
 	[ ! -d pygattlib ] && git clone https://github.com/matthewelse/pygattlib
 	cd pygattlib &&	sudo python3 setup.py install
 	;;


### PR DESCRIPTION
I hope this works also for Ubuntu and other debian
based distros. It's at least needed on raspian.

Fixing problems like this:

```
building 'gattlib' extension
arm-linux-gnueabihf-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector-strong -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fPIC -DVERSION="5.25" -I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include -Isrc/bluez -I/usr/include/python3.4m -c src/gattservices.cpp -o build/temp.linux-armv7l-3.4/src/gattservices.o
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
In file included from /usr/include/boost/python/detail/prefix.hpp:13:0,
                 from /usr/include/boost/python/list.hpp:8,
                 from src/gattlib.h:11,
                 from src/gattservices.cpp:12:
/usr/include/boost/python/detail/wrap_python.hpp:50:23: fatal error: pyconfig.h: No such file or directory
 # include <pyconfig.h>
                       ^
compilation terminated.
error: command 'arm-linux-gnueabihf-gcc' failed with exit status 1
```

Also setuptools might not be installed by default. 
