### PR TITLE
Remove unnecessary method

### DIFF
--- a/nuimo/nuimo.py
+++ b/nuimo/nuimo.py
@@ -126,10 +126,6 @@ class Controller(gatt.Device):
             self.listener.started_connecting()
         super().connect()
 
-    def connect_succeded(self):
-        super().connect_succeeded()
-        super().connect_succeeded()
-
     def connect_failed(self, error):
         super().connect_failed(error)
         if self.listener:


### PR DESCRIPTION
The method was supposed to override the base class's method because of wrong spelling. Anyway, it wasn't called at all. Even if it had been called, it was wrongly implemented (calling the super method twice).